### PR TITLE
Make the addon compatible with Kodi 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ MTV Katsomo addon for Kodi
 This is completely unofficial addon for MTV Katsomo.
 
 # Prerequisites
-- Kodi 17.4
+- Kodi 19
 - Inputstream.adaptive >=v2.0.4
 - Libwidevine

--- a/addon.py
+++ b/addon.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from urlparse import parse_qsl
+from urllib.parse import parse_qsl
 import json
 
 from resources.lib.kodihelper import KodiHelper
@@ -169,7 +169,7 @@ def router(paramstring):
             helper.reset_credentials()
     elif 'action' in params:
         if params['action'] == 'list_programs':
-            if 'category' in params.keys():
+            if 'category' in list(params.keys()):
                 list_programs(category=params['category'])
             else:
                 list_programs()

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.katsomo" version="0.1.7" name="MTV Katsomo" provider-name="Dis90">
 <requires>
-  <import addon="xbmc.python" version="2.24.0"/>
+  <import addon="xbmc.python" version="3.0.0"/>
   <import addon="script.module.requests" version="2.9.1"/>
   <import addon="inputstream.adaptive" version="2.0.4"/>
 </requires>

--- a/resources/lib/katsomo.py
+++ b/resources/lib/katsomo.py
@@ -5,7 +5,7 @@ A Kodi-agnostic library for Katsomo
 import os
 import json
 import codecs
-import cookielib
+import http.cookiejar
 import time
 import xml.etree.ElementTree as ET
 from datetime import datetime
@@ -18,7 +18,7 @@ class Katsomo(object):
         self.debug = debug
         self.http_session = requests.Session()
         self.settings_folder = settings_folder
-        self.cookie_jar = cookielib.LWPCookieJar(os.path.join(self.settings_folder, 'cookie_file'))
+        self.cookie_jar = http.cookiejar.LWPCookieJar(os.path.join(self.settings_folder, 'cookie_file'))
         try:
             self.cookie_jar.load(ignore_discard=True, ignore_expires=True)
         except IOError:
@@ -35,12 +35,12 @@ class Katsomo(object):
     def log(self, string):
         if self.debug:
             try:
-                print '[Katsomo]: %s' % string
+                print('[Katsomo]: %s' % string)
             except UnicodeEncodeError:
                 # we can't anticipate everything in unicode they might throw at
                 # us, but we can handle a simple BOM
-                bom = unicode(codecs.BOM_UTF8, 'utf8')
-                print '[Katsomo]: %s' % string.replace(bom, '')
+                bom = str(codecs.BOM_UTF8, 'utf8')
+                print('[Katsomo]: %s' % string.replace(bom, ''))
             except:
                 pass
 
@@ -75,12 +75,12 @@ class Katsomo(object):
         try:
             error = json.loads(response)
             if isinstance(error, dict):
-                if 'error' in error.keys():
-                    if 'message' in error['error'].keys():
+                if 'error' in list(error.keys()):
+                    if 'message' in list(error['error'].keys()):
                         raise self.KatsomoError(error['error']['message'])
-                    elif 'code' in error['error'].keys():
+                    elif 'code' in list(error['error'].keys()):
                         raise self.KatsomoError(error['error']['code'])
-                if 'response' in error.keys(): # Response is not always error but we need this to check if login is OK
+                if 'response' in list(error.keys()): # Response is not always error but we need this to check if login is OK
                     if error['response']['code'] == 'AUTHENTICATION_FAILED':
                         raise self.KatsomoError(error['response']['code'])
             elif isinstance(error, str):

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -137,7 +137,7 @@ class KodiHelper(object):
         stream = self.k.get_stream(video_id)
 
         playitem = xbmcgui.ListItem(path=stream['mpd_url'])
-        playitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        playitem.setProperty('inputstream', 'inputstream.adaptive')
         playitem.setProperty('inputstream.adaptive.manifest_type', 'mpd')
 
         if stream['drm_protected']:

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import re
 
-from katsomo import Katsomo
+from .katsomo import Katsomo
 
 import xbmc
 import xbmcvfs
@@ -121,7 +121,7 @@ class KodiHelper(object):
         if content:
             xbmcplugin.setContent(self.handle, content)
 
-        recursive_url = self.base_url + '?' + urllib.urlencode(params)
+        recursive_url = self.base_url + '?' + urllib.parse.urlencode(params)
 
         if items is False:
             xbmcplugin.addDirectoryItem(self.handle, recursive_url, listitem, folder)


### PR DESCRIPTION
I converted the addon to python 3 as it's required with the latest stable version of Kodi. I tested on my Android TV box with Kodi 19.1 and was able to do playback